### PR TITLE
Add CircleCI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,11 +13,11 @@ jobs:
       - checkout:
           path: "~/project"
       - run:
-        name: "checksum test proj"
-        command: checksum "Honeycomb.Tests.csproj"
+          name: "checksum test proj"
+          command: checksum "Honeycomb.Tests.csproj"
       - run:
-        name: "checksum parent proj"
-        command: checksum "~/project/src/Honeycomb/Honeycomb.csproj"
+          name: "checksum parent proj"
+          command: checksum "~/project/src/Honeycomb/Honeycomb.csproj"
       # - run:
       #     name: "Install project dependencies"
       #     command: dotnet.exe restore

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ jobs:
     working_directory: "~/project/test/Honeycomb.Tests/"
     steps:
       - checkout
+          path: "~/project"
       # - run:
       #     name: "Install project dependencies"
       #     command: dotnet.exe restore

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,21 +13,25 @@ jobs:
       - checkout:
           path: "~/project"
       - run:
-          name: "find all proj files"
+          name: "Generate cache seed"
           command: |
             Get-ChildItem -Path $HOME\project\*.csproj -Recurse `
             | Sort-Object Name `
             | ForEach-Object { Get-Content $_ } `
             | Out-File -FilePath .\cache-seed -Append
+      - restore_cache:
+          keys:
+            - dotnet-packages-v1-{{ checksum "cache-seed" }}
       - run:
-          name: "check seed"
-          command: Get-Content .\cache-seed
-      # - run:
-      #     name: "Install project dependencies"
-      #     command: dotnet.exe restore
-      # - run:
-      #     name: "Run tests"
-      #     command: dotnet.exe test -v n
+          name: "Install project dependencies"
+          command: dotnet.exe restore
+      - save_cache:
+          paths:
+            - C:\Users\circleci\.nuget\packages
+          key: dotnet-packages-v1-{{ checksum "cache-seed" }}
+      - run:
+          name: "Run tests"
+          command: dotnet.exe test -v n
 workflows:
   test:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,8 @@ orbs:
 commands:
   setup:
     steps:
-      - checkout
+      - checkout:
+          path: "~/project"
       - run:
           name: "Generate cache seed"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
       name: windows/default
     working_directory: "~/project/test/Honeycomb.Tests/"
     steps:
-      - checkout
+      - checkout:
           path: "~/project"
       # - run:
       #     name: "Install project dependencies"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  windows: circleci/windows@2.2.0
+  windows: circleci/windows@2.4.0
 
 jobs:
   test:
@@ -12,20 +12,17 @@ jobs:
     steps:
       - checkout:
           path: "~/project"
-      # - run:
-      #     name: "Install project dependencies"
-      #     command: dotnet.exe restore
-      # - run:
-      #     name: "Run tests"
-      #     command: dotnet.exe test -v n --results-directory:test_coverage --collect:"Code Coverage"
+      - run:
+          name: "Install project dependencies"
+          command: dotnet.exe restore
+      - run:
+          name: "Run tests"
+          command: dotnet.exe test -v n --results-directory:test_coverage --collect:"Code Coverage"
       - run:
           name: "Print working directory"
           command: pwd
-      - run:
-          name: "wut"
-          command: dir          
-      # - store_artifacts:
-      #     path: C:\Users\circleci\project\test_coverage
+      - store_artifacts:
+          path: C:\Users\circleci\project\test_coverage
 workflows:
   test:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,9 @@ jobs:
           name: "Build release package"
           command: dotnet.exe pack --configuration release
       - store_artifacts:
-          path: bin\release
+          path: src\Honeycomb\bin\Release
+      - store_artifacts:
+          path: src\Honeycomb.AspNetCore\bin\Release
 
 workflows:
   main:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,9 @@ jobs:
       - run:
           name: "Print working directory"
           command: pwd
+      - run:
+          name: "wut"
+          command: dir          
       # - store_artifacts:
       #     path: C:\Users\circleci\project\test_coverage
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
           path: "~/project"
       - run:
           name: "find all proj files"
-          command: Get-ChildItem -Path $HOME\project\*.csproj -Recurse
+          command: Get-ChildItem -Path $HOME\project\*.csproj -Recurse | Sort-Object Name | ForEach-Object { Get-Content $_ }
       # - run:
       #     name: "Install project dependencies"
       #     command: dotnet.exe restore

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,12 +17,7 @@ jobs:
           command: dotnet.exe restore
       - run:
           name: "Run tests"
-          command: dotnet.exe test -v n --results-directory:test_coverage --collect:"Code Coverage"
-      - run:
-          name: "Print working directory"
-          command: pwd
-      - store_artifacts:
-          path: C:\Users\circleci\project\test_coverage
+          command: dotnet.exe test -v n
 workflows:
   test:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,11 +13,8 @@ jobs:
       - checkout:
           path: "~/project"
       - run:
-          name: "checksum test proj"
-          command: checksum "Honeycomb.Tests.csproj"
-      - run:
-          name: "checksum parent proj"
-          command: checksum "~/project/src/Honeycomb/Honeycomb.csproj"
+          name: "find all proj files"
+          command: Get-ChildItem -Path $HOME\project\*.csproj -Recurse
       # - run:
       #     name: "Install project dependencies"
       #     command: dotnet.exe restore

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,21 @@ jobs:
       - run:
           name: "Run tests"
           command: dotnet.exe test -v n
+  build:
+    executor:
+      name: windows/default
+    working_directory: "~/project/src/Honeycomb/"
+    steps:
+      - setup
+      - run:
+          name: "Build release package"
+          command: dotnet.exe pack --configuration release
+      - run:
+          command: dir bin\release
 workflows:
   main:
     jobs:
       - test
+      - build:
+          requires:
+            - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,12 +6,11 @@ orbs:
 commands:
   setup:
     steps:
-      - checkout:
-          path: "~/project"
+      - checkout
       - run:
           name: "Generate cache seed"
           command: |
-            Get-ChildItem -Path $HOME\project\*.csproj -Recurse `
+            Get-ChildItem -Path $HOME\*.csproj -Recurse `
             | Sort-Object Name `
             | ForEach-Object { Get-Content $_ } `
             | Out-File -FilePath .\cache-seed -Append
@@ -25,7 +24,19 @@ commands:
           paths:
             - C:\Users\circleci\.nuget\packages
           key: dotnet-packages-v1-{{ checksum "cache-seed" }}
+
+jobs:
+  test:
+    executor:
+      name: windows/default
+    steps:
+      - setup
+      - run:
+          name: "Run tests"
+          command: dotnet.exe test -v n
   build:
+    executor:
+      name: windows/default
     steps:
       - setup
       - run:
@@ -34,36 +45,10 @@ commands:
       - store_artifacts:
           path: bin\release
 
-jobs:
-  test:
-    executor:
-      name: windows/default
-    working_directory: "~/project/test/Honeycomb.Tests/"
-    steps:
-      - setup
-      - run:
-          name: "Run tests"
-          command: dotnet.exe test -v n
-  build_standard:
-    executor:
-      name: windows/default
-    working_directory: "~/project/src/Honeycomb/"
-    steps:
-      - build
-  build_core:
-    executor:
-      name: windows/default
-    working_directory: "~/project/src/Honeycomb.AspNetCore/"
-    steps:
-      - build
-
 workflows:
   main:
     jobs:
       - test
-      - build_standard:
-          requires:
-            - test
-      - build_core:
+      - build:
           requires:
             - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,11 +13,17 @@ jobs:
       - checkout:
           path: "~/project"
       - run:
-          name: "Install project dependencies"
-          command: dotnet.exe restore
+        name: "checksum test proj"
+        command: checksum "Honeycomb.Tests.csproj"
       - run:
-          name: "Run tests"
-          command: dotnet.exe test -v n
+        name: "checksum parent proj"
+        command: checksum "~/project/src/Honeycomb/Honeycomb.csproj"
+      # - run:
+      #     name: "Install project dependencies"
+      #     command: dotnet.exe restore
+      # - run:
+      #     name: "Run tests"
+      #     command: dotnet.exe test -v n
 workflows:
   test:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,10 +50,20 @@ jobs:
     working_directory: "~/project/src/Honeycomb/"
     steps:
       - build
+  build_core:
+    executor:
+      name: windows/default
+    working_directory: "~/project/src/Honeycomb.AspNetCore/"
+    steps:
+      - build
+
 workflows:
   main:
     jobs:
       - test
       - build_standard:
+          requires:
+            - test
+      - build_core:
           requires:
             - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,28 @@
+version: 2.1
+
+orbs:
+  windows: circleci/windows@2.2.0
+
+jobs:
+  test:
+    description: Setup and run tests
+    executor:
+      name: windows/default
+    working_directory: "~/project/test/Honeycomb.Tests/"
+    steps:
+      - checkout
+      - run:
+          name: "Install project dependencies"
+          command: dotnet.exe restore
+      - run:
+          name: "Run tests"
+          command: dotnet.exe test -v n --results-directory:test_coverage --collect:"Code Coverage"
+      - run:
+          name: "Print working directory"
+          command: pwd
+      - store_artifacts:
+          path: C:\Users\circleci\project\test_coverage
+workflows:
+  test:
+    jobs:
+      - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,14 @@ jobs:
           path: "~/project"
       - run:
           name: "find all proj files"
-          command: Get-ChildItem -Path $HOME\project\*.csproj -Recurse | Sort-Object Name | ForEach-Object { Get-Content $_ }
+          command: |
+            Get-ChildItem -Path $HOME\project\*.csproj -Recurse `
+            | Sort-Object Name `
+            | ForEach-Object { Get-Content $_ } `
+            | Out-File -FilePath .\cache-seed -Append
+      - run:
+          name: "check seed"
+          command: Get-Content .\cache-seed
       # - run:
       #     name: "Install project dependencies"
       #     command: dotnet.exe restore

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,14 @@ commands:
           paths:
             - C:\Users\circleci\.nuget\packages
           key: dotnet-packages-v1-{{ checksum "cache-seed" }}
+  build:
+    steps:
+      - setup
+      - run:
+          name: "Build release package"
+          command: dotnet.exe pack --configuration release
+      - store_artifacts:
+          path: bin\release
 
 jobs:
   test:
@@ -36,21 +44,16 @@ jobs:
       - run:
           name: "Run tests"
           command: dotnet.exe test -v n
-  build:
+  build_standard:
     executor:
       name: windows/default
     working_directory: "~/project/src/Honeycomb/"
     steps:
-      - setup
-      - run:
-          name: "Build release package"
-          command: dotnet.exe pack --configuration release
-      - run:
-          command: dir bin\release
+      - build
 workflows:
   main:
     jobs:
       - test
-      - build:
+      - build_standard:
           requires:
             - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,15 +3,10 @@ version: 2.1
 orbs:
   windows: circleci/windows@2.4.0
 
-jobs:
-  test:
-    description: Setup and run tests
-    executor:
-      name: windows/default
-    working_directory: "~/project/test/Honeycomb.Tests/"
+commands:
+  setup:
     steps:
-      - checkout:
-          path: "~/project"
+      - checkout
       - run:
           name: "Generate cache seed"
           command: |
@@ -29,10 +24,18 @@ jobs:
           paths:
             - C:\Users\circleci\.nuget\packages
           key: dotnet-packages-v1-{{ checksum "cache-seed" }}
+
+jobs:
+  test:
+    executor:
+      name: windows/default
+    working_directory: "~/project/test/Honeycomb.Tests/"
+    steps:
+      - setup
       - run:
           name: "Run tests"
           command: dotnet.exe test -v n
 workflows:
-  test:
+  main:
     jobs:
       - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,8 +44,10 @@ jobs:
           command: dotnet.exe pack --configuration release
       - store_artifacts:
           path: src\Honeycomb\bin\Release
+          destination: Honeycomb-package
       - store_artifacts:
           path: src\Honeycomb.AspNetCore\bin\Release
+          destination: Honeycomb.AspNetCore-package
 
 workflows:
   main:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,17 +11,17 @@ jobs:
     working_directory: "~/project/test/Honeycomb.Tests/"
     steps:
       - checkout
-      - run:
-          name: "Install project dependencies"
-          command: dotnet.exe restore
-      - run:
-          name: "Run tests"
-          command: dotnet.exe test -v n --results-directory:test_coverage --collect:"Code Coverage"
+      # - run:
+      #     name: "Install project dependencies"
+      #     command: dotnet.exe restore
+      # - run:
+      #     name: "Run tests"
+      #     command: dotnet.exe test -v n --results-directory:test_coverage --collect:"Code Coverage"
       - run:
           name: "Print working directory"
           command: pwd
-      - store_artifacts:
-          path: C:\Users\circleci\project\test_coverage
+      # - store_artifacts:
+      #     path: C:\Users\circleci\project\test_coverage
 workflows:
   test:
     jobs:


### PR DESCRIPTION
Test the Honeycomb.Tests project and build Honeycomb and Honeycomb.AspNetCore packages.

* doesn't publish a release to GitHub, yet. I think we need to transfer ownership in [NuGet](https://www.nuget.org/packages/Honeycomb/) first
* built packages can be found in the [artifacts](https://app.circleci.com/pipelines/github/honeycombio/libhoney-dotnet/19/workflows/661e5d9a-46bc-42ef-8421-6f36f53bf561/jobs/23/artifacts) tab for each build