### PR TITLE
More packaging metadata & CircleCI publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,25 +34,69 @@ jobs:
       - run:
           name: "Run tests"
           command: dotnet.exe test -v n
-  build:
+  package:
     executor:
       name: windows/default
     steps:
       - setup
+      - run: mkdir -p ~/artifacts
       - run:
           name: "Build release package"
-          command: dotnet.exe pack --configuration release
+          command: dotnet.exe pack --configuration release --output ~/artifacts -p:version=${CIRCLE_TAG}
       - store_artifacts:
-          path: src\Honeycomb\bin\Release
-          destination: Honeycomb-package
-      - store_artifacts:
-          path: src\Honeycomb.AspNetCore\bin\Release
-          destination: Honeycomb.AspNetCore-package
+          path: ~/artifacts
+  publish_github:
+    docker:
+      - image: cibuilds/github:0.13.0
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: "Publish Release on GitHub"
+          command: |
+            echo "about to publish to tag ${CIRCLE_TAG}"
+            ls -l ~/artifacts/*
+            ghr -draft -n ${CIRCLE_TAG} -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ~/artifacts
+  publish_nuget:
+    executor:
+      name: windows/default
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: "Publishing to nuget.org"
+          command: dotnet.exe nuget push --api-key="${NUGET_APIKEY}" ~/artifacts/*.nupkg
 
 workflows:
-  main:
+  version: 2
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - main
     jobs:
       - test
-      - build:
+  build:
+    jobs:
+      - test
+      - package:
           requires:
             - test
+          filters: &tag_filters
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
+      - publish_github:
+          context: Honeycomb Secrets for Public Repos
+          requires:
+            - package
+          filters: *tag_filters
+      - publish_nuget:
+          context: Honeycomb Secrets for Public Repos
+          requires:
+            - package
+          filters: *tag_filters

--- a/src/Honeycomb.AspNetCore/Honeycomb.AspNetCore.csproj
+++ b/src/Honeycomb.AspNetCore/Honeycomb.AspNetCore.csproj
@@ -3,15 +3,21 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <PackageId>Honeycomb.AspNetCore</PackageId>
-    <Version>1.0.0</Version>
+    <VersionPrefix>1.1.0</VersionPrefix>
+    <VeresionSuffix>local</VeresionSuffix>
     <Authors>Hoenycomb</Authors>
     <Company>Honeycomb</Company>
+    <Title>Client package for Honeycomb.io</Title>
     <Description>Client package for Honeycomb.io</Description>
-    <Copyright>Copyright 2019</Copyright>
+    <Copyright>Copyright 2021</Copyright>
     <PackageIcon>honeycomb.png</PackageIcon>
-    <PackageTags>Observability;Tracing;AspNetCore</PackageTags>
+    <PackageTags>Honeycomb;libhoney;Observability;Tracing;AspNetCore</PackageTags>
     <PackageProjectUrl>https://github.com/honeycombio/libhoney-dotnet</PackageProjectUrl>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageReleaseNotes>https://github.com/honeycombio/libhoney-dotnet/releases</PackageReleaseNotes>
+    <RepositoryUrl>https://github.com/honeycombio/libhoney-dotnet.git</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Honeycomb/Honeycomb.csproj
+++ b/src/Honeycomb/Honeycomb.csproj
@@ -3,22 +3,25 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>Honeycomb</PackageId>
-    <Version>1.0.0</Version>
+    <VersionPrefix>1.1.0</VersionPrefix>
+    <VeresionSuffix>local</VeresionSuffix>
     <Authors>Hoenycomb</Authors>
     <Company>Honeycomb</Company>
+    <Title>Client package for Honeycomb.io</Title>
     <Description>Client package for Honeycomb.io</Description>
-    <Copyright>Copyright 2019</Copyright>
+    <Copyright>Copyright 2021</Copyright>
     <PackageIcon>honeycomb.png</PackageIcon>
-    <PackageTags>Observability;Tracing</PackageTags>
+    <PackageTags>Honeycomb;libhoney;Observability;Tracing</PackageTags>
     <PackageProjectUrl>https://github.com/honeycombio/libhoney-dotnet</PackageProjectUrl>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageReleaseNotes>https://github.com/honeycombio/libhoney-dotnet/releases</PackageReleaseNotes>
+    <RepositoryUrl>https://github.com/honeycombio/libhoney-dotnet.git</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
   </PropertyGroup>
 
   <ItemGroup>
     <None Include="../../honeycomb.png" Pack="true" PackagePath="\" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Http" Version="2.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />


### PR DESCRIPTION
Updates the csproj files for both distributable projects to have more accurate packaging metadata and updates the CircleCI config to setup nightly builds and also create a draft Github release & publish to nuget.org when tagging the repo.