### PR TITLE
Fix CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,10 @@ workflows:
       - test
   build:
     jobs:
-      - test
+      - test:
+          filters:
+            tags:
+              only: /.*/
       - package:
           requires:
             - test


### PR DESCRIPTION
CircleCI config requires a filter for each job if any job has a filter. This updates the config to add an always filter for the test command.