### PR TITLE
Update default SendFrequency to 10 seconds

### DIFF
--- a/src/Honeycomb/Models/HoneycombApiSettings.cs
+++ b/src/Honeycomb/Models/HoneycombApiSettings.cs
@@ -21,7 +21,7 @@ namespace Honeycomb.Models
         public int BatchSize { get; set; } = 100;
 
         /// <summary>
-        /// The time between sending event batches. Expressed in millisseconds.
+        /// The time between sending event batches. Expressed in milliseconds.
         /// </summary>
         /// <value></value>
         public int SendFrequency { get; set; } = 10000;

--- a/src/Honeycomb/Models/HoneycombApiSettings.cs
+++ b/src/Honeycomb/Models/HoneycombApiSettings.cs
@@ -21,10 +21,10 @@ namespace Honeycomb.Models
         public int BatchSize { get; set; } = 100;
 
         /// <summary>
-        /// The time between sending event batches.
+        /// The time between sending event batches. Expressed in millisseconds.
         /// </summary>
         /// <value></value>
-        public int SendFrequency { get; set; } = 60;
+        public int SendFrequency { get; set; } = 10000;
 
         /// <summary>
         /// The base URL to send event data to


### PR DESCRIPTION
Fixes #16.

Updates the default `SendFrequency` to **10000ms** (10 seconds) to match documentation and default value in example `appsettings.json`.