### PR TITLE
Stopping the timer before calculating the elapsedmilliseconds

### DIFF
--- a/src/Honeycomb.AspNetCore/Middleware/HoneycombMiddleware.cs
+++ b/src/Honeycomb.AspNetCore/Middleware/HoneycombMiddleware.cs
@@ -47,7 +47,7 @@ namespace Honeycomb.AspNetCore.Middleware
             try
             {
                 await _next.Invoke(context);
-            
+                stopwatch.Stop();
             	ev.Data.TryAdd("name", $"{context.GetRouteValue("controller")}#{context.GetRouteValue("action")}");
                 ev.Data.TryAdd("action", context.GetRouteValue("action"));
                 ev.Data.TryAdd("controller", context.GetRouteValue("controller"));


### PR DESCRIPTION
The middleware has a bug. The timer to calculate the request time is started but not stopped. Fixing the bug!