### PR TITLE
Add WriteKey and deprecate TeamId

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ Configuration can either be done through adding this to your appSettings.json
 ```json
 {
   "HoneycombSettings": {
-    "TeamId": "blah",
-    "DefaultDataSet": "MyTestDataSet",
+    "WriteKey": "<your-writekey>",
+    "DefaultDataSet": "<your-dataset>",
     "BatchSize": 100,
     "SendFrequency": 10000
   }
@@ -79,8 +79,8 @@ Or alternatively, you can create an instance of  `HoneycombApiSettings` and pass
     ...
 
     services.AddHoneycomb(new HoneycombApiSettings {
-        TeamId = "blah",
-        DefaultDataSet = "MyTestDataSet"
+        WriteKey = "<your-writekey>",
+        DefaultDataSet = "<your-dataset>"
         BatchSize = 100,
         SendFrequency = 10000,
     });

--- a/Sample/Sample.csproj
+++ b/Sample/Sample.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Honeycomb.AspNetCore" Version="1.0.0" />
+    <ProjectReference Include="..\src\Honeycomb.AspNetCore\Honeycomb.AspNetCore.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Sample/appsettings.json
+++ b/Sample/appsettings.json
@@ -5,7 +5,7 @@
     }
   },
   "HoneycombSettings": {
-    "TeamId": "{WRITE_KEY}",
+    "WriteKey": "{WRITE_KEY}",
     "DefaultDataSet": "dotnet-core",
     "BatchSize": 100,
     "SendFrequency": 10000

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,10 +1,10 @@
 ## Integrating with AspNet Core
 
 ### Before you get started
-You'll need your Honeycomb TeamId, this is your API Key please find it below
+You'll need your Honeycomb WriteKey, this is your API Key please find it below
 
 ```
-${TeamId}
+${WriteKey}
 ```
 
 ### Add the package
@@ -22,7 +22,7 @@ Then, in your projects `appsettings.json` add the following settings:
 ```json
 {
   "HoneycombSettings": {
-    "TeamId": "blah",
+    "WriteKey": "blah",
     "DefaultDataSet": "MyTestDataSet",
     "BatchSize": 100,
     "SendFrequency": 10000

--- a/src/Honeycomb.AspNetCore/Honeycomb.AspNetCore.csproj
+++ b/src/Honeycomb.AspNetCore/Honeycomb.AspNetCore.csproj
@@ -21,8 +21,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Honeycomb\Honeycomb.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Include="../../honeycomb.png" Pack="true" PackagePath="\" />
-    <PackageReference Include="Honeycomb" Version="1.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1" />
     <PackageReference Include="Microsoft.AspNetCore.Routing" Version="2.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="2.1" />

--- a/src/Honeycomb/HoneycombService.cs
+++ b/src/Honeycomb/HoneycombService.cs
@@ -79,7 +79,7 @@ namespace Honeycomb
                         new ProductHeaderValue("libhoney-dotnet", _assemblyVersion)));
             message.Headers.Add("X-Honeycomb-Event-Time",
                 ev.EventTime.ToUniversalTime().ToString(@"{0:yyyy-MM-ddTHH\:mm\:ss.fffK}"));
-            message.Headers.Add("X-Honeycomb-Team", _settings.Value.TeamId);
+            message.Headers.Add("X-Honeycomb-Team", _settings.Value.WriteKey);
 
             var resp = await client.SendAsync(message);
             if (!resp.IsSuccessStatusCode)
@@ -104,8 +104,8 @@ namespace Honeycomb
 
             var message = new HttpRequestMessage();
 
-            var sendItems = items.Select(i => 
-                new { 
+            var sendItems = items.Select(i =>
+                new {
                     time = i.EventTime.ToUniversalTime().ToString(@"yyyy-MM-ddTHH\:mm\:ss.fffK"),
                     data = i.Data
                     });
@@ -117,7 +117,7 @@ namespace Honeycomb
             message.Headers.UserAgent.Add(
                     new ProductInfoHeaderValue(
                         new ProductHeaderValue("libhoney-dotnet", _assemblyVersion)));
-            message.Headers.Add("X-Honeycomb-Team", _settings.Value.TeamId);
+            message.Headers.Add("X-Honeycomb-Team", _settings.Value.WriteKey);
 
             var resp = await client.SendAsync(message);
             if (!resp.IsSuccessStatusCode)

--- a/src/Honeycomb/Models/HoneycombApiSettings.cs
+++ b/src/Honeycomb/Models/HoneycombApiSettings.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Honeycomb.Models
 {
     public class HoneycombApiSettings
@@ -6,7 +8,18 @@ namespace Honeycomb.Models
         /// The TeamId within Honeycomb.
         /// </summary>
         /// <value></value>
-        public string TeamId { get; set; }
+        [ObsoleteAttribute("This property is obsolete. Use WriteKey instead.", false)]
+        public string TeamId
+        {
+            get { return WriteKey; }
+            set { WriteKey = value; }
+        }
+
+        /// <summary>
+        /// The WriteKey within Honeycomb.
+        /// </summary>
+        /// <value></value>
+        public string WriteKey { get; set; }
 
         /// <summary>
         /// The default dataset to apply to each event.


### PR DESCRIPTION
Fixes #14.

Adds `HoneycombApiSettings.WriteKey` to replace `TeamId` to improve consistency between beeline implementations. TeamId is marked as deprecated and any usage manipulates the new property to ensure backwards compatibility. Docs and usage examples also updated.

Also includes replacing package references in Honeycomb.AspnetCore and the Sample projects with project references so it uses the local projects instead of depending on downloaded packages. This allows easier code debugging and for any changes in the root project to be reflected in sub-projects without having to release the main project first.