### PR TITLE
Prepare v1.1.1. release

### DIFF
--- a/CHANGLOG.md
+++ b/CHANGLOG.md
@@ -1,0 +1,21 @@
+# libhonet-dotnet Changelog
+
+## v1.1.1
+
+### Improvements:
+
+- Add WriteKey and deprecate TeamId (#30)
+
+### Fixes:
+
+- Update AddHoneycomb with settings instance to use Action<> (#29)
+- Fix typo in VersionSuffux project file property (#31)
+- Update default SendFrequency to 10 seconds (#27)
+- Stopping the timer before calculating the elapsedmilliseconds (#28)
+
+## v1.1.0
+
+### Improvements:
+
+- Change the ApiHost setting to include the url scheme (#21)
+- Add support for setting the api send target through configuration (#20)

--- a/src/Honeycomb.AspNetCore/Honeycomb.AspNetCore.csproj
+++ b/src/Honeycomb.AspNetCore/Honeycomb.AspNetCore.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <PackageId>Honeycomb.AspNetCore</PackageId>
     <VersionPrefix>1.1.1</VersionPrefix>
-    <VeresionSuffix>local</VeresionSuffix>
+    <VersionSuffix>local</VersionSuffix>
     <Authors>Hoenycomb</Authors>
     <Company>Honeycomb</Company>
     <Title>Client package for Honeycomb.io</Title>

--- a/src/Honeycomb.AspNetCore/Honeycomb.AspNetCore.csproj
+++ b/src/Honeycomb.AspNetCore/Honeycomb.AspNetCore.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <PackageId>Honeycomb.AspNetCore</PackageId>
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <VersionPrefix>1.1.1</VersionPrefix>
     <VeresionSuffix>local</VeresionSuffix>
     <Authors>Hoenycomb</Authors>
     <Company>Honeycomb</Company>

--- a/src/Honeycomb.AspNetCore/Honeycomb.AspNetCore.csproj
+++ b/src/Honeycomb.AspNetCore/Honeycomb.AspNetCore.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <PackageId>Honeycomb.AspNetCore</PackageId>
     <VersionPrefix>1.1.1</VersionPrefix>
-    <VersionSuffix>local</VersionSuffix>
     <Authors>Hoenycomb</Authors>
     <Company>Honeycomb</Company>
     <Title>Client package for Honeycomb.io</Title>

--- a/src/Honeycomb/Honeycomb.csproj
+++ b/src/Honeycomb/Honeycomb.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>Honeycomb</PackageId>
     <VersionPrefix>1.1.1</VersionPrefix>
-    <VersionSuffix>local</VersionSuffix>
     <Authors>Hoenycomb</Authors>
     <Company>Honeycomb</Company>
     <Title>Client package for Honeycomb.io</Title>

--- a/src/Honeycomb/Honeycomb.csproj
+++ b/src/Honeycomb/Honeycomb.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>Honeycomb</PackageId>
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <VersionPrefix>1.1.1</VersionPrefix>
     <VersionSuffix>local</VersionSuffix>
     <Authors>Hoenycomb</Authors>
     <Company>Honeycomb</Company>


### PR DESCRIPTION
Updates package versions to v1.1.1 and adds a Changelog (includes entries for v1.1.0 & v1.1.1).

Also removes the `VersionSuffix` property from csproj as they were causing a problem with CI building the packages. We don't really need it anyway, it was a nice to have to separate local builds from official packages.