### PR TITLE
Build example as part of CI test phase

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,9 @@ jobs:
       - run:
           name: "Run tests"
           command: dotnet.exe test -v n
-      - run: dotnet build examples/Sample/Sample.csproj
+      - run:
+          name: Build example app
+          command: dotnet build examples/Sample/Sample.csproj
 
   package:
     executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,8 @@ jobs:
       - run:
           name: "Run tests"
           command: dotnet.exe test -v n
+      - run: dotnet build examples/Sample/Sample.csproj
+
   package:
     executor:
       name: windows/default


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
We have a local example that demonstrates some expected usage patterns but is not tied directly to what it's the main projects. This change updates the CI build phase to also build the example app to ensure we do not accidentally break APIs.

- Closes #64 

## Short description of the changes
- Update CI test step to build the example app

<img width="1176" alt="image" src="https://user-images.githubusercontent.com/3481731/168083831-c10e843d-e2a9-47cb-a9bd-25f6863d79ff.png">