### PR TITLE
feat: support classic ingest keys

### DIFF
--- a/src/Honeycomb/Honeycomb.csproj
+++ b/src/Honeycomb/Honeycomb.csproj
@@ -29,4 +29,8 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
   </ItemGroup>
 
+  <ItemGroup Condition=" $(SIGNED) != 'true' ">
+    <InternalsVisibleTo Include="Honeycomb.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/src/Honeycomb/Models/HoneycombApiSettings.cs
+++ b/src/Honeycomb/Models/HoneycombApiSettings.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
 
 namespace Honeycomb.Models
@@ -9,6 +10,9 @@ namespace Honeycomb.Models
 
         private readonly ILogger<HoneycombApiSettings> _logger;
         private string _dataset;
+        private const string ClassicKeyRegex = "^[a-f0-9]*$";
+        private const string IngestClassicKeyRegex = "^hc[a-z]ic_[a-z0-9]*$";
+
 
         public HoneycombApiSettings()
             : this(LoggerFactory.Create(builder => builder.AddConsole()).CreateLogger<HoneycombApiSettings>())
@@ -79,6 +83,20 @@ namespace Honeycomb.Models
         /// </summary>
         public string ApiHost { get; set; } = "https://api.honeycomb.io";
 
+        /*private bool IsClassic() {
+            if (WriteKey == null || WriteKey.Length == 0) {
+                return true;
+            } 
+            else if (WriteKey.Length == 32) 
+            {
+                return Regex.Match(WriteKey, ClassicKeyRegex).Success;
+            }
+            else if (WriteKey.Length == 64)
+            {
+             return Regex.Match(WriteKey, IngestClassicKeyRegex).Success;
+            }
+            return false;
+        }*/
         private bool IsClassic => string.IsNullOrWhiteSpace(WriteKey) || WriteKey.Length == 32;
     }
 }

--- a/src/Honeycomb/Models/HoneycombApiSettings.cs
+++ b/src/Honeycomb/Models/HoneycombApiSettings.cs
@@ -83,12 +83,12 @@ namespace Honeycomb.Models
         /// </summary>
         public string ApiHost { get; set; } = "https://api.honeycomb.io";
 
-        public bool IsClassic() {
-            if (WriteKey == null || WriteKey.Length == 0) 
+        internal bool IsClassic() {
+            if (WriteKey == null || WriteKey.Length == 0)
             {
               return true;
-            } 
-            else if (WriteKey.Length == 32) 
+            }
+            else if (WriteKey.Length == 32)
             {
               return Regex.Match(WriteKey, ClassicKeyRegex).Success;
             }

--- a/src/Honeycomb/Models/HoneycombApiSettings.cs
+++ b/src/Honeycomb/Models/HoneycombApiSettings.cs
@@ -48,7 +48,7 @@ namespace Honeycomb.Models
         {
             get
             {
-                if (IsClassic) {
+                if (IsClassic()) {
                     return _dataset;
                 }
                 if (string.IsNullOrWhiteSpace(_dataset))
@@ -83,7 +83,7 @@ namespace Honeycomb.Models
         /// </summary>
         public string ApiHost { get; set; } = "https://api.honeycomb.io";
 
-        /*private bool IsClassic() {
+        public bool IsClassic() {
             if (WriteKey == null || WriteKey.Length == 0) {
                 return true;
             } 
@@ -96,7 +96,6 @@ namespace Honeycomb.Models
              return Regex.Match(WriteKey, IngestClassicKeyRegex).Success;
             }
             return false;
-        }*/
-        private bool IsClassic => string.IsNullOrWhiteSpace(WriteKey) || WriteKey.Length == 32;
+        }
     }
 }

--- a/src/Honeycomb/Models/HoneycombApiSettings.cs
+++ b/src/Honeycomb/Models/HoneycombApiSettings.cs
@@ -84,7 +84,7 @@ namespace Honeycomb.Models
         public string ApiHost { get; set; } = "https://api.honeycomb.io";
 
         internal bool IsClassic() {
-            if (WriteKey == null || WriteKey.Length == 0)
+            if (String.IsNullOrEmpty(WriteKey))
             {
               return true;
             }

--- a/src/Honeycomb/Models/HoneycombApiSettings.cs
+++ b/src/Honeycomb/Models/HoneycombApiSettings.cs
@@ -85,15 +85,15 @@ namespace Honeycomb.Models
 
         public bool IsClassic() {
             if (WriteKey == null || WriteKey.Length == 0) {
-                return true;
+              return true;
             } 
             else if (WriteKey.Length == 32) 
             {
-                return Regex.Match(WriteKey, ClassicKeyRegex).Success;
+              return Regex.Match(WriteKey, ClassicKeyRegex).Success;
             }
             else if (WriteKey.Length == 64)
             {
-             return Regex.Match(WriteKey, IngestClassicKeyRegex).Success;
+              return Regex.Match(WriteKey, IngestClassicKeyRegex).Success;
             }
             return false;
         }

--- a/src/Honeycomb/Models/HoneycombApiSettings.cs
+++ b/src/Honeycomb/Models/HoneycombApiSettings.cs
@@ -84,7 +84,8 @@ namespace Honeycomb.Models
         public string ApiHost { get; set; } = "https://api.honeycomb.io";
 
         public bool IsClassic() {
-            if (WriteKey == null || WriteKey.Length == 0) {
+            if (WriteKey == null || WriteKey.Length == 0) 
+            {
               return true;
             } 
             else if (WriteKey.Length == 32) 

--- a/test/Honeycomb.Tests/HoneycombApiSettingsTests.cs
+++ b/test/Honeycomb.Tests/HoneycombApiSettingsTests.cs
@@ -35,5 +35,13 @@ namespace Honeycomb.Models
             };
             settings.DefaultDataSet.ShouldBe(expected);
         }
+
+        public void IsClassic()
+        {
+            var settings = new HoneycombApiSettings();
+            settings.IsClassic().ShouldBeFalse();
+            settings.WriteKey = "";
+            settings.IsClassic().ShouldBeFalse();
+        }
    }
 }

--- a/test/Honeycomb.Tests/HoneycombApiSettingsTests.cs
+++ b/test/Honeycomb.Tests/HoneycombApiSettingsTests.cs
@@ -36,12 +36,22 @@ namespace Honeycomb.Models
             settings.DefaultDataSet.ShouldBe(expected);
         }
 
-        public void IsClassic()
+
+        [Theory]
+        [InlineData("", true)]
+        [InlineData("12345678901234567890123456789012", true)]
+        [InlineData("hcaic_1234567890123456789012345678901234567890123456789012345678", true)]
+        [InlineData("kgvSpPwegJshQkuowXReLD", false)]
+        [InlineData("hcaic_12345678901234567890123456", false)]
+        [InlineData("hcxik_01hqk4k20cjeh63wca8vva5stw70nft6m5n8wr8f5mjx3762s8269j50wc", false)]
+        public void IsClassic(string key, bool expected)
         {
-            var settings = new HoneycombApiSettings();
-            settings.IsClassic().ShouldBeFalse();
-            settings.WriteKey = "";
-            settings.IsClassic().ShouldBeFalse();
+            var settings = new HoneycombApiSettings
+            {
+                WriteKey = key,
+                DefaultDataSet = "my-dataset"
+            };
+            settings.IsClassic().ShouldBe(expected);
         }
    }
 }

--- a/test/Honeycomb.Tests/HoneycombApiSettingsTests.cs
+++ b/test/Honeycomb.Tests/HoneycombApiSettingsTests.cs
@@ -14,12 +14,18 @@ namespace Honeycomb.Models
         [InlineData("", "my-service", "my-service")]
         [InlineData("", " my-service ", " my-service ")]
         [InlineData("c1a551c000d68f9ed1e96432ac1a3380", "", "")]
+        [InlineData("hcaic_1234567890123456789012345678901234567890123456789012345678", "", "")]
         [InlineData("c1a551c000d68f9ed1e96432ac1a3380", "my-service", "my-service")]
+        [InlineData("hcaic_1234567890123456789012345678901234567890123456789012345678", "my-service", "my-service")]
         [InlineData("c1a551c000d68f9ed1e96432ac1a3380", " my-service ", " my-service ")]
+        [InlineData("hcaic_1234567890123456789012345678901234567890123456789012345678", " my-service ", " my-service ")]
         // defaults to unknown_dataset and trims dataset if set
         [InlineData("d68f9ed1e96432ac1a3380", "", "unknown_dataset")]
+        [InlineData("hcxik_01hqk4k20cjeh63wca8vva5stw70nft6m5n8wr8f5mjx3762s8269j50wc", "", "unknown_dataset")]
         [InlineData("d68f9ed1e96432ac1a3380", "my-service", "my-service")]
+        [InlineData("hcxik_01hqk4k20cjeh63wca8vva5stw70nft6m5n8wr8f5mjx3762s8269j50wc", "my-service", "my-service")]
         [InlineData("d68f9ed1e96432ac1a3380", " my-service ", "my-service")]
+        [InlineData("hcxik_01hqk4k20cjeh63wca8vva5stw70nft6m5n8wr8f5mjx3762s8269j50wc", " my-service ", "my-service")]
         public void Dataset(string writekey, string dataset, string expected)
         {
             var settings = new HoneycombApiSettings


### PR DESCRIPTION
## Which problem is this PR solving?

- We've released Ingest Keys, but need to update the key detection logic to allow Ingest Keys to be used to send data to Classic environments.

## Short description of the changes

- Updated the `IsClassic` lambda expression to a function with the new Regex logic
- Updated the Dataset test to include cases for the new key format**

** **Note:** For most other libhoneys we have made this IsClassic function public. However, since .NET does not have a beeline, it seemed like it would be best to leave this as a private method. Since it is private, it also becomes harder to write a unit test for, which is why I am testing it through `DefaultDataset`. Let me know if there's a preferred approach to testing private methods through reflection or something like that.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206670034694150